### PR TITLE
Move images to autopilotpattern repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-triton-elk
+ELK autopilot pattern
 ==========
 
 *[Autopilot pattern](http://autopilotpattern.io/) implementation of ELK*
@@ -91,8 +91,8 @@ This repo also includes a Docker Compose file for starting Nginx containers that
 ```sh
 $ ./test.sh -p elk test syslog
 Starting Nginx log source...
-Pulling nginx_syslog (0x74696d/triton-nginx:latest)...
-latest: Pulling from 0x74696d/triton-nginx
+Pulling nginx_syslog (autopilotpattern/nginx:latest)...
+latest: Pulling from autopilotpattern/nginx
 ...
 Creating elk_nginx_syslog_1
 Waiting for Nginx to register as healthy...

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@
 # The Kibana application queries the ES cluster
 
 kibana:
-    image: 0x74696d/triton-kibana:latest
+    image: autopilotpattern/kibana:latest
     mem_limit: 1g
     restart: always
     labels:
@@ -26,7 +26,7 @@ kibana:
 # The logstash container is the target of Docker log drivers
 
 logstash:
-    image: 0x74696d/triton-logstash:latest
+    image: autopilotpattern/logstash:latest
     mem_limit: 1g
     restart: always
     labels:
@@ -53,7 +53,7 @@ logstash:
 # master-only and data-only ES nodes.
 
 elasticsearch:
-    image: 0x74696d/triton-elasticsearch:latest
+    image: autopilotpattern/elasticsearch:latest
     mem_limit: 4g
     restart: always
     labels:

--- a/makefile
+++ b/makefile
@@ -12,10 +12,10 @@ build:
 	docker-compose -f local-compose.yml -p elk build kibana logstash
 
 ship:
-	docker tag -f elk_kibana 0x74696d/triton-kibana
-	docker tag -f elk_logstash 0x74696d/triton-logstash
-	docker push 0x74696d/triton-kibana
-	docker push 0x74696d/triton-logstash
+	docker tag -f elk_kibana autopilotpattern/kibana
+	docker tag -f elk_logstash autopilotpattern/logstash
+	docker push autopilotpattern/kibana
+	docker push autopilotpattern/logstash
 
 
 # -------------------------------------------

--- a/test.sh
+++ b/test.sh
@@ -90,7 +90,7 @@ test() {
            -e CONSUL="${consul}" \
            -e CONTAINERBUDDY="$(cat ./nginx/containerbuddy.json)" \
            -e NGINX_CONF="$(cat ./nginx/nginx.conf)" \
-           0x74696d/triton-nginx \
+           autopilotpattern/nginx \
            /opt/containerbuddy/containerbuddy nginx -g "daemon off;"
 
     poll-for-page "http://$(getPublicUrl nginx-$logtype 80)" \


### PR DESCRIPTION
@misterbisson this updates the repo to have container images moved under the autopilotpattern org.

The new images have been pushed to:
https://hub.docker.com/r/autopilotpattern/elasticsearch/
https://hub.docker.com/r/autopilotpattern/logstash/
https://hub.docker.com/r/autopilotpattern/kibana/
https://hub.docker.com/r/autopilotpattern/nginx/
