### PR TITLE
Multi-platform support for URL helpers

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -217,7 +217,7 @@ poll-for-page() {
     echo
 
 
-    echo $3
+    echo "$3"
     if which xdg-open &>/dev/null; then
             # A *nix machine that supplies xdg-open
             BROWSER_COMMAND=xdg-open
@@ -234,7 +234,7 @@ poll-for-page() {
             echo -n 'Web interface available at: '
     fi
 
-    $BROWSER_COMMAND $1
+    $BROWSER_COMMAND "$1"
 
 }
 

--- a/test.sh
+++ b/test.sh
@@ -220,21 +220,21 @@ poll-for-page() {
     echo "$3"
     if which xdg-open &>/dev/null; then
             # A *nix machine that supplies xdg-open
-            BROWSER_COMMAND=xdg-open
+            browser_command=xdg-open
     elif which x-www-browser &>/dev/null; then
             # A *nix machine with alternatives system
-            BROWSER_COMMAND=x-www-browser
+            browser_command=x-www-browser
     elif which open &>/dev/null && ! ls -l $(which open) | grep openvt &> /dev/null; then
             # "open" exists and isn't a symlink to openvt, so hopefully 
             # it is the Apple OS X "open" utility. 
-            BROWSER_COMMAND=open
+            browser_command=open
     else
             # Fall back to echoing URL to terminal 
-            BROWSER_COMMAND=echo
+            browser_command=echo
             echo -n 'Web interface available at: '
     fi
 
-    $BROWSER_COMMAND "$1"
+    $browser_command "$1"
 
 }
 

--- a/test.sh
+++ b/test.sh
@@ -216,13 +216,26 @@ poll-for-page() {
     done
     echo
 
-    which open &>/dev/null
-    if [ $? -eq 0 ]; then
-        echo "$3"
-        open "$1"
+
+    echo $3
+    if which xdg-open &>/dev/null; then
+            # A *nix machine that supplies xdg-open
+            BROWSER_COMMAND=xdg-open
+    elif which x-www-browser &>/dev/null; then
+            # A *nix machine with alternatives system
+            BROWSER_COMMAND=x-www-browser
+    elif which open &>/dev/null && ! ls -l $(which open) | grep openvt &> /dev/null; then
+            # "open" exists and isn't a symlink to openvt, so hopefully 
+            # it is the Apple OS X "open" utility. 
+            BROWSER_COMMAND=open
     else
-        echo "Web interface available at $1"
+            # Fall back to echoing URL to terminal 
+            BROWSER_COMMAND=echo
+            echo -n 'Web interface available at: '
     fi
+
+    $BROWSER_COMMAND $1
+
 }
 
 doStuff() {


### PR DESCRIPTION
test.sh was Macintosh-only, so I added support for xdg-open, x-www-browser, and a test to see if "open" is a symlink to openvt. 

Accidentally using "openvt" is what causes the "Couldn't get a file descriptor referring to the console" error.

If xdg-open, x-www-browser, and a non-symlink "open" can't be found, the script echoes the URL to the terminal.
